### PR TITLE
feat: Add web UI for real-time monitoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ build:
 	$(GOBUILD) -race -o $(BINARY_NAME) -v ./cmd/certmitm
 
 test:
-	$(GOTEST) -v ./...
+	@echo "Running tests..."
+	@$(GOTEST) -v ./cmd/... ./internal/... ./pkg/...
 
 clean:
 	$(GOCLEAN)

--- a/cmd/certmitm/main.go
+++ b/cmd/certmitm/main.go
@@ -27,6 +27,8 @@ var (
 	autoTest     = flag.Bool("autotest", true, "Automatically test all methods for each domain")
 	retrySeconds = flag.Int("retryseconds", 86400, "Time in seconds to wait before retesting a domain (default: 24 hours)")
 	maxAttempts  = flag.Int("maxattempts", 1, "Maximum number of attempts for each test type before moving to the next test")
+	webui        = flag.Bool("webui", false, "Enable the web UI")
+	webuiAddr    = flag.String("webui-addr", ":8081", "Address to listen on for the web UI")
 )
 
 func main() {
@@ -53,6 +55,9 @@ func main() {
 	if err != nil {
 		logger.Fatalf("Failed to initialize proxy server: %v", err)
 	}
+
+	// Set the broadcaster on the logger
+	logger.SetBroadcaster(proxyServer)
 
 	// Set the max attempts for each test type
 	proxyServer.SetMaxAttempts(*maxAttempts)
@@ -103,6 +108,16 @@ func main() {
 			logger.Fatalf("Proxy server error: %v", err)
 		}
 	}()
+
+	// Start web UI if enabled
+	if *webui {
+		go func() {
+			logger.Infof("Starting web UI on %s", *webuiAddr)
+			if err := proxyServer.StartWebUI(*webuiAddr); err != nil {
+				logger.Fatalf("Web UI error: %v", err)
+			}
+		}()
+	}
 
 	logger.Infof("CertMITM proxy started, HTTP on %s, HTTPS on %s", *listenAddr, *listenAddrs)
 	logger.Infof("Press Ctrl+C to stop")

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/gocertmitm
 go 1.24.1
 
 require golang.org/x/sys v0.33.0
+
+require github.com/gorilla/websocket v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 golang.org/x/sys v0.33.0 h1:q3i8TbbEz+JRD9ywIRlyRAQbM0qF7hu24q3teo2hbuw=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -1,6 +1,7 @@
 package logging
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -9,6 +10,11 @@ import (
 	"sync"
 	"time"
 )
+
+// Broadcaster defines the interface for broadcasting messages
+type Broadcaster interface {
+	Broadcast(message []byte)
+}
 
 // Logger provides logging functionality
 type Logger struct {
@@ -22,6 +28,7 @@ type Logger struct {
 	nextReqID     uint64
 	reqIDMap      map[string]string // Maps clientIP:host to request ID
 	mu            sync.Mutex        // Mutex to protect concurrent access to reqIDMap and nextReqID
+	broadcaster   Broadcaster
 }
 
 // NewLogger creates a new logger
@@ -82,51 +89,104 @@ func (l *Logger) Close() error {
 	return nil
 }
 
+// SetBroadcaster sets the broadcaster for the logger
+func (l *Logger) SetBroadcaster(b Broadcaster) {
+	l.broadcaster = b
+}
+
 // Infof logs an info message
 func (l *Logger) Infof(format string, v ...interface{}) {
-	l.infoLogger.Printf(format, v...)
+	msg := fmt.Sprintf(format, v...)
+	l.infoLogger.Print(msg)
+	if l.broadcaster != nil {
+		logEntry := map[string]string{"type": "log", "message": msg}
+		jsonEntry, _ := json.Marshal(logEntry)
+		l.broadcaster.Broadcast(jsonEntry)
+	}
 }
 
 // InfoWithRequestIDf logs an info message with a request ID
 func (l *Logger) InfoWithRequestIDf(reqID, format string, v ...interface{}) {
-	l.infoLogger.Printf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+	msg := fmt.Sprintf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+	l.infoLogger.Print(msg)
+	if l.broadcaster != nil {
+		logEntry := map[string]string{"type": "log", "message": msg}
+		jsonEntry, _ := json.Marshal(logEntry)
+		l.broadcaster.Broadcast(jsonEntry)
+	}
 }
 
 // Errorf logs an error message
 func (l *Logger) Errorf(format string, v ...interface{}) {
-	l.errorLogger.Printf(format, v...)
+	msg := fmt.Sprintf(format, v...)
+	l.errorLogger.Print(msg)
+	if l.broadcaster != nil {
+		logEntry := map[string]string{"type": "log", "message": msg}
+		jsonEntry, _ := json.Marshal(logEntry)
+		l.broadcaster.Broadcast(jsonEntry)
+	}
 }
 
 // ErrorWithRequestIDf logs an error message with a request ID
 func (l *Logger) ErrorWithRequestIDf(reqID, format string, v ...interface{}) {
-	l.errorLogger.Printf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+	msg := fmt.Sprintf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+	l.errorLogger.Print(msg)
+	if l.broadcaster != nil {
+		logEntry := map[string]string{"type": "log", "message": msg}
+		jsonEntry, _ := json.Marshal(logEntry)
+		l.broadcaster.Broadcast(jsonEntry)
+	}
 }
 
 // Verbosef logs a verbose message
 func (l *Logger) Verbosef(format string, v ...interface{}) {
 	if l.verbose {
-		l.verboseLogger.Printf(format, v...)
+		msg := fmt.Sprintf(format, v...)
+		l.verboseLogger.Print(msg)
+		if l.broadcaster != nil {
+			logEntry := map[string]string{"type": "log", "message": msg}
+			jsonEntry, _ := json.Marshal(logEntry)
+			l.broadcaster.Broadcast(jsonEntry)
+		}
 	}
 }
 
 // VerboseWithRequestIDf logs a verbose message with a request ID
 func (l *Logger) VerboseWithRequestIDf(reqID, format string, v ...interface{}) {
 	if l.verbose {
-		l.verboseLogger.Printf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+		msg := fmt.Sprintf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+		l.verboseLogger.Print(msg)
+		if l.broadcaster != nil {
+			logEntry := map[string]string{"type": "log", "message": msg}
+			jsonEntry, _ := json.Marshal(logEntry)
+			l.broadcaster.Broadcast(jsonEntry)
+		}
 	}
 }
 
 // Debugf logs a debug message
 func (l *Logger) Debugf(format string, v ...interface{}) {
 	if l.debug {
-		l.debugLogger.Printf(format, v...)
+		msg := fmt.Sprintf(format, v...)
+		l.debugLogger.Print(msg)
+		if l.broadcaster != nil {
+			logEntry := map[string]string{"type": "log", "message": msg}
+			jsonEntry, _ := json.Marshal(logEntry)
+			l.broadcaster.Broadcast(jsonEntry)
+		}
 	}
 }
 
 // DebugWithRequestIDf logs a debug message with a request ID
 func (l *Logger) DebugWithRequestIDf(reqID, format string, v ...interface{}) {
 	if l.debug {
-		l.debugLogger.Printf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+		msg := fmt.Sprintf("[%s] "+format, append([]interface{}{reqID}, v...)...)
+		l.debugLogger.Print(msg)
+		if l.broadcaster != nil {
+			logEntry := map[string]string{"type": "log", "message": msg}
+			jsonEntry, _ := json.Marshal(logEntry)
+			l.broadcaster.Broadcast(jsonEntry)
+		}
 	}
 }
 

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -82,6 +82,11 @@ type Server struct {
 	clientDestMu        sync.Mutex                                // Mutex for clientDestinations
 	recentDomains       []string                                  // Track recently accessed domains
 	recentDomainsMu     sync.Mutex                                // Mutex for recentDomains
+	hub                 *Hub
+}
+
+func (s *Server) Broadcast(message []byte) {
+	s.hub.broadcast <- message
 }
 
 // NewServer creates a new proxy server
@@ -117,7 +122,10 @@ func NewServer(httpAddr, httpsAddr string, certManager *certificates.Manager, lo
 		directTunnelDomains: make(map[string]bool),
 		clientDestinations:  make(map[string]string), // Track client IP to destination mapping
 		recentDomains:       make([]string, 0, 10),   // Track up to 10 recent domains
+		hub:                 newHub(),
 	}
+
+	go server.hub.run()
 
 	// Create HTTP server
 	httpHandler := http.HandlerFunc(server.handleHTTP)

--- a/internal/proxy/web.go
+++ b/internal/proxy/web.go
@@ -1,0 +1,98 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gocertmitm/internal/web"
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{
+	ReadBufferSize:  1024,
+	WriteBufferSize: 1024,
+}
+
+type Hub struct {
+	clients    map[*websocket.Conn]bool
+	broadcast  chan []byte
+	register   chan *websocket.Conn
+	unregister chan *websocket.Conn
+}
+
+func newHub() *Hub {
+	return &Hub{
+		broadcast:  make(chan []byte),
+		register:   make(chan *websocket.Conn),
+		unregister: make(chan *websocket.Conn),
+		clients:    make(map[*websocket.Conn]bool),
+	}
+}
+
+func (h *Hub) run() {
+	for {
+		select {
+		case client := <-h.register:
+			h.clients[client] = true
+		case client := <-h.unregister:
+			if _, ok := h.clients[client]; ok {
+				delete(h.clients, client)
+				client.Close()
+			}
+		case message := <-h.broadcast:
+			for client := range h.clients {
+				err := client.WriteMessage(websocket.TextMessage, message)
+				if err != nil {
+					client.Close()
+					delete(h.clients, client)
+				}
+			}
+		}
+	}
+}
+
+func (s *Server) StartWebUI(addr string) error {
+	handler, err := web.GetHandler()
+	if err != nil {
+		return err
+	}
+
+	http.Handle("/", handler)
+	http.HandleFunc("/api/status", s.handleAPIStatus)
+	http.HandleFunc("/ws", s.handleWebSocket)
+
+	return http.ListenAndServe(addr, nil)
+}
+
+func (s *Server) handleAPIStatus(w http.ResponseWriter, r *http.Request) {
+	status := struct {
+		RecentDomains []string `json:"recent_domains"`
+	}{
+		RecentDomains: s.GetRecentDomains(),
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(status)
+}
+
+func (s *Server) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		s.logger.Errorf("Failed to upgrade WebSocket connection: %v", err)
+		return
+	}
+	s.hub.register <- conn
+
+	defer func() {
+		s.hub.unregister <- conn
+		conn.Close()
+	}()
+
+	for {
+		// We don't need to read messages from the client, just keep the connection open
+		// The client will close the connection when it's done
+		if _, _, err := conn.NextReader(); err != nil {
+			break
+		}
+	}
+}

--- a/internal/web/index.html
+++ b/internal/web/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CertMITM Web UI</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>CertMITM Web UI</h1>
+    <div id="app">
+        <h2>Recent Domains</h2>
+        <ul id="recent-domains"></ul>
+
+        <h2>Logs</h2>
+        <pre id="logs"></pre>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/internal/web/script.js
+++ b/internal/web/script.js
@@ -1,0 +1,23 @@
+const recentDomainsList = document.getElementById('recent-domains');
+const logs = document.getElementById('logs');
+
+function fetchData() {
+    fetch('/api/status')
+        .then(response => response.json())
+        .then(data => {
+            recentDomainsList.innerHTML = data.recent_domains.map(domain => `<li>${domain}</li>`).join('');
+        });
+}
+
+fetchData();
+
+const socket = new WebSocket(`ws://${location.host}/ws`);
+
+socket.onmessage = function(event) {
+    const data = JSON.parse(event.data);
+    if (data.type === 'update') {
+        fetchData();
+    } else if (data.type === 'log') {
+        logs.textContent += data.message + '\n';
+    }
+};

--- a/internal/web/style.css
+++ b/internal/web/style.css
@@ -1,0 +1,7 @@
+body {
+    font-family: sans-serif;
+}
+
+#app {
+    padding: 1em;
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -1,0 +1,18 @@
+package web
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+)
+
+//go:embed index.html style.css script.js
+var content embed.FS
+
+func GetHandler() (http.Handler, error) {
+	fs, err := fs.Sub(content, ".")
+	if err != nil {
+		return nil, err
+	}
+	return http.FileServer(http.FS(fs)), nil
+}


### PR DESCRIPTION
This commit introduces a web-based user interface for `certmitm` to provide real-time monitoring of the proxy's activity.

The new web UI can be enabled using the `--webui` command-line flag. When enabled, it runs a web server on the address specified by `--webui-addr` (default: `:8081`).

Features:
- A simple and clean web page to display information.
- A list of recently accessed domains.
- A real-time log stream that displays the same output as the console.
- WebSockets are used for efficient, real-time communication between the backend and the frontend.
- Frontend assets (HTML, CSS, JS) are embedded into the Go binary for easy distribution.

The implementation includes:
- A new `internal/web` package for frontend assets and embedding logic.
- A new web server and WebSocket hub in `internal/proxy`.
- Modifications to the logger to broadcast log messages to connected WebSocket clients.
- New command-line flags to control the web UI.
- The `Makefile` has been updated to correctly run tests on all relevant packages.